### PR TITLE
refactor: 카카오 api 회원가입 및 로그인

### DIFF
--- a/solumon-backend/.gitignore
+++ b/solumon-backend/.gitignore
@@ -1,3 +1,4 @@
+application.yml
 HELP.md
 .gradle
 build/

--- a/solumon-backend/src/main/java/com/example/solumonbackend/SolumonBackendApplication.java
+++ b/solumon-backend/src/main/java/com/example/solumonbackend/SolumonBackendApplication.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
-@EnableJpaAuditing
 public class SolumonBackendApplication {
 
   public static void main(String[] args) {

--- a/solumon-backend/src/main/java/com/example/solumonbackend/global/exception/ErrorCode.java
+++ b/solumon-backend/src/main/java/com/example/solumonbackend/global/exception/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
   NOT_CORRECT_PASSWORD("비밀번호가 일치하지 않습니다."),
   ALREADY_REGISTERED_NICKNAME("이미 등록된 닉네임 입니다. 다른 닉네임을 사용해 주세요"),
   INVALID_REFRESH_TOKEN("refresh token이 유효하지 않습니다."),
-  NOT_FOUND_TOKEN_SET("해당 accessToken으로 저장된 token을 찾을 수 없습니다.");
+  NOT_FOUND_TOKEN_SET("해당 accessToken으로 저장된 token을 찾을 수 없습니다."),
+  UNREGISTERED_ACCOUNT("탈퇴한 회원입니다.");
 
   private final String description;
 

--- a/solumon-backend/src/main/java/com/example/solumonbackend/member/controller/MemberController.java
+++ b/solumon-backend/src/main/java/com/example/solumonbackend/member/controller/MemberController.java
@@ -1,19 +1,13 @@
 package com.example.solumonbackend.member.controller;
 
-import com.example.solumonbackend.member.model.MemberDetail;
-import com.example.solumonbackend.member.service.KakaoService;
-import com.example.solumonbackend.member.entity.Member;
 import com.example.solumonbackend.member.model.GeneralSignInDto;
 import com.example.solumonbackend.member.model.GeneralSignUpDto;
 import com.example.solumonbackend.member.model.MemberDetail;
+import com.example.solumonbackend.member.service.KakaoService;
 import com.example.solumonbackend.member.service.MemberService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -51,17 +45,6 @@ public class MemberController {
   @PostMapping("/sign-in/general")
   public ResponseEntity<GeneralSignInDto.Response> signIn(@Valid @RequestBody GeneralSignInDto.Request request) {
     return ResponseEntity.ok(memberService.signIn(request));
-  }
-
-  @PostMapping("/update-token/kakao")
-  public ResponseEntity<?> kakaoTokenUpdate(@AuthenticationPrincipal MemberDetail memberDetail,
-                                            @RequestHeader("X-AUTH-TOKEN") String oldAccessToken) {
-    return ResponseEntity.ok(kakaoService.kakaoTokenUpdate(memberDetail, oldAccessToken));
-  }
-
-  @PostMapping("/log-out/kakao")
-  public ResponseEntity<?> kakaoLogOut(@AuthenticationPrincipal MemberDetail memberDetail) {
-    return ResponseEntity.ok(kakaoService.kakaoLogOut(memberDetail));
   }
 
   @GetMapping("/exception")

--- a/solumon-backend/src/main/java/com/example/solumonbackend/member/controller/MemberController.java
+++ b/solumon-backend/src/main/java/com/example/solumonbackend/member/controller/MemberController.java
@@ -38,8 +38,8 @@ public class MemberController {
   }
 
   @PostMapping("/sign-in/kakao")
-  public ResponseEntity<?> kakaoLogIn(@RequestParam String code) {
-    return ResponseEntity.ok(kakaoService.kakaoLogIn(code));
+  public ResponseEntity<?> kakaoSignIn(@RequestParam String code) {
+    return ResponseEntity.ok(kakaoService.kakaoSignIn(code));
   }
 
   @PostMapping("/sign-in/general")

--- a/solumon-backend/src/main/java/com/example/solumonbackend/member/model/KakaoSignUpDto.java
+++ b/solumon-backend/src/main/java/com/example/solumonbackend/member/model/KakaoSignUpDto.java
@@ -9,7 +9,9 @@ public class KakaoSignUpDto {
   @Builder
   public static class Response {
     private Long memberId;
-    private String accessToken;
-    private String refreshToken;
+    private Long kakaoId;
+    private String email;
+    private String nickname;
+
   }
 }

--- a/solumon-backend/src/main/java/com/example/solumonbackend/member/model/LogOutDto.java
+++ b/solumon-backend/src/main/java/com/example/solumonbackend/member/model/LogOutDto.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class KakaoLogOutDto {
+public class LogOutDto {
 
   @Builder
   public static class Response {

--- a/solumon-backend/src/main/java/com/example/solumonbackend/member/service/KakaoService.java
+++ b/solumon-backend/src/main/java/com/example/solumonbackend/member/service/KakaoService.java
@@ -2,13 +2,12 @@ package com.example.solumonbackend.member.service;
 
 import com.example.solumonbackend.global.exception.ErrorCode;
 import com.example.solumonbackend.global.exception.MemberException;
+import com.example.solumonbackend.global.security.JwtTokenProvider;
 import com.example.solumonbackend.member.entity.Member;
 import com.example.solumonbackend.member.entity.RefreshToken;
+import com.example.solumonbackend.member.model.CreateTokenDto;
 import com.example.solumonbackend.member.model.KakaoLogInDto;
-import com.example.solumonbackend.member.model.KakaoLogOutDto;
 import com.example.solumonbackend.member.model.KakaoSignUpDto;
-import com.example.solumonbackend.member.model.KakaoTokenUpdateDto;
-import com.example.solumonbackend.member.model.MemberDetail;
 import com.example.solumonbackend.member.repository.MemberRepository;
 import com.example.solumonbackend.member.repository.RefreshTokenRedisRepository;
 import com.example.solumonbackend.member.type.MemberRole;
@@ -21,11 +20,11 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -35,19 +34,18 @@ public class KakaoService {
   private final MemberRepository memberRepository;
   private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
+  private final JwtTokenProvider jwtTokenProvider;
+
   @Value("${kakao-rest-api-key}")
   private String clientId;
-  @Value("${kakao-admin-key}")
-  private String adminKey;
 
+  @Transactional
   public KakaoSignUpDto.Response kakaoSignUp(String code, String nickname) {
 
     JsonElement tokenInfoJson = getKakaoTokenByCode(code, "http://localhost:8080/user/sign-up/kakao");
     unlinkTokenAndThrowExceptionIfNoEmail(tokenInfoJson);
 
     String accessToken = tokenInfoJson.getAsJsonObject().get("access_token").getAsString();
-    String refreshToken = tokenInfoJson.getAsJsonObject().get("refresh_token").getAsString();
-
     JsonElement userInfoJson = getUserInfoFromToken(accessToken);
     Long kakaoIdNum = userInfoJson.getAsJsonObject().get("id").getAsLong();
     String email = userInfoJson.getAsJsonObject().get("kakao_account").getAsJsonObject().get("email").getAsString();
@@ -60,34 +58,38 @@ public class KakaoService {
         .build();
     memberRepository.save(member);
 
-    refreshTokenRedisRepository.save(RefreshToken.builder()
-        .accessToken(accessToken)
-        .refreshToken(refreshToken)
-        .build());
-
     return KakaoSignUpDto.Response.builder()
         .memberId(member.getMemberId())
-        .accessToken(accessToken)
-        .refreshToken(refreshToken)
+        .kakaoId(member.getKakaoId())
+        .email(member.getEmail())
+        .nickname(member.getNickname())
         .build();
   }
 
+  @Transactional
   public KakaoLogInDto.Response kakaoLogIn(String code) {
     JsonElement tokenInfoJson = getKakaoTokenByCode(code, "http://localhost:8080/user/sign-up/kakao");
-    String accessToken = tokenInfoJson.getAsJsonObject().get("access_token").getAsString();
-    String refreshToken = tokenInfoJson.getAsJsonObject().get("refresh_token").getAsString();
+    String kakaoAccessToken = tokenInfoJson.getAsJsonObject().get("access_token").getAsString();
 
-    String email = getUserInfoFromToken(accessToken)
+    String email = getUserInfoFromToken(kakaoAccessToken)
         .getAsJsonObject().get("kakao_account")
         .getAsJsonObject().get("email").getAsString();
 
     Member member = memberRepository.findByEmail(email)
         .orElseThrow(() -> new MemberException(ErrorCode.NOT_FOUND_MEMBER));
 
-    refreshTokenRedisRepository.save(RefreshToken.builder()
-        .accessToken(accessToken)
-        .refreshToken(refreshToken)
-        .build());
+    checkIfNotUnregisteredMember(member);
+
+    CreateTokenDto createTokenDto = CreateTokenDto.builder()
+        .memberId(member.getMemberId())
+        .email(member.getEmail())
+        .role(member.getRole())
+        .build();
+
+    String accessToken = jwtTokenProvider.createAccessToken(member.getEmail(), createTokenDto.getRoles());
+    String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail(), createTokenDto.getRoles());
+
+    refreshTokenRedisRepository.save(new RefreshToken(accessToken, refreshToken));
 
     return KakaoLogInDto.Response.builder()
         .memberId(member.getMemberId())
@@ -96,57 +98,6 @@ public class KakaoService {
         .build();
   }
 
-  public KakaoTokenUpdateDto.Response kakaoTokenUpdate(MemberDetail memberDetail, String oldAccessToken) {
-    RefreshToken refreshToken = refreshTokenRedisRepository.findByAccessToken(oldAccessToken)
-        .orElseThrow(() -> new MemberException(ErrorCode.ACCESS_TOKEN_NOT_FOUND));
-
-    JsonElement tokenInfoJson = getKakaoTokenByRefresh(refreshToken.getRefreshToken());
-    Set<String> tokenInfoJsonKeySet = tokenInfoJson.getAsJsonObject().keySet();
-    String newAccessToken = tokenInfoJson.getAsJsonObject().get("access_token").getAsString();
-    String newRefreshToken = "";
-
-    if (tokenInfoJsonKeySet.contains("refresh_token")) {
-      newRefreshToken = tokenInfoJson.getAsJsonObject().get("refresh_token").getAsString();
-    } else {
-      newRefreshToken = refreshToken.getRefreshToken();
-    }
-
-    refreshTokenRedisRepository.save(RefreshToken.builder()
-        .accessToken(newAccessToken)
-        .refreshToken(newRefreshToken)
-        .build());
-    refreshTokenRedisRepository.deleteByAccessToken(oldAccessToken);
-
-    return KakaoTokenUpdateDto.Response.builder()
-        .memberId(memberDetail.getMember().getMemberId())
-        .accessToken(newAccessToken)
-        .refreshToken(newRefreshToken)
-        .build();
-  }
-
-  public KakaoLogOutDto.Response kakaoLogOut(MemberDetail memberDetail) {
-    try {
-      HttpURLConnection connection
-          = (HttpURLConnection) new URL("https://kapi.kakao.com/v1/user/logout").openConnection();
-      connection.setRequestMethod("POST");
-      connection.setDoOutput(true);
-      connection.setRequestProperty("Authorization", "KakaoAK " + adminKey);
-
-      if (connection.getResponseCode() != 200) {
-        return KakaoLogOutDto.Response.builder()
-            .memberId(memberDetail.getMember().getMemberId())
-            .status("로그아웃에 실패했습니다.")
-            .build();
-      }
-    }  catch (IOException e) {
-      log.error("kakaoLogout에서 IO exception 발생");
-    }
-
-    return KakaoLogOutDto.Response.builder()
-        .memberId(memberDetail.getMember().getMemberId())
-        .status("로그아웃에 성공하였습니다.")
-        .build();
-  }
 
   public JsonElement getKakaoTokenByCode(String code, String redirectUri) {
     try {
@@ -169,33 +120,6 @@ public class KakaoService {
       }
     } catch (IOException e) {
       log.error("getKakaoTokenByCode에서 IOException 발생: " + e.getMessage());
-    }
-    return null;
-  }
-
-  public JsonElement getKakaoTokenByRefresh(String refreshToken) {
-    try {
-      HttpURLConnection connection
-          = (HttpURLConnection) new URL("https://kauth.kakao.com/oauth/token").openConnection();
-      connection.setRequestMethod("POST");
-      connection.setDoOutput(true);
-
-      if (connection.getResponseCode() != 200) {
-        throw new MemberException(ErrorCode.REFRESH_TOKEN_EXPIRED);
-      }
-
-      try (BufferedWriter bufferedWriter = new BufferedWriter(new OutputStreamWriter(connection.getOutputStream()))) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("grant_type=refresh_token")
-            .append("&client_id=").append(clientId)
-            .append("&refresh_token=").append(refreshToken);
-
-        bufferedWriter.write(sb.toString());
-        bufferedWriter.flush();
-        return readJson(connection);
-      }
-    } catch (IOException e) {
-      log.error("getKakaoTokenByRefresh에서 IOException 발생: " + e.getMessage());
     }
     return null;
   }
@@ -244,5 +168,11 @@ public class KakaoService {
       log.error("getUserInfoFromToken에서 IOException 발생: " + e.getMessage());
     }
     return null;
+  }
+
+  private void checkIfNotUnregisteredMember(Member member) {
+    if (member.getUnregisteredAt() != null) {
+      throw new MemberException(ErrorCode.UNREGISTERED_ACCOUNT);
+    }
   }
 }

--- a/solumon-backend/src/main/java/com/example/solumonbackend/member/service/KakaoService.java
+++ b/solumon-backend/src/main/java/com/example/solumonbackend/member/service/KakaoService.java
@@ -67,7 +67,7 @@ public class KakaoService {
   }
 
   @Transactional
-  public KakaoLogInDto.Response kakaoLogIn(String code) {
+  public KakaoLogInDto.Response kakaoSignIn(String code) {
     JsonElement tokenInfoJson = getKakaoTokenByCode(code, "http://localhost:8080/user/sign-up/kakao");
     String kakaoAccessToken = tokenInfoJson.getAsJsonObject().get("access_token").getAsString();
 


### PR DESCRIPTION
**AS-IS**
- 논의한대로 카카오 토큰으로 권한을 확인하는 것이 아니라, 정보만 카카오 토큰에서 가져오고 access / refresh는 jwt로 발행하는 것으로 수정
- 이에 따라 updateKakaoToken / kakaoLogOut 삭제
- 이외 리뷰 반영한 수정

**TO-BE**
- 테스트 

